### PR TITLE
XBMC media state enum string instead of boolean

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -188,7 +188,8 @@ module.exports = {
           hidden: yes
       lastMediaState:
         description: ""
-        type: "boolean"
+        type: "string"
+        default: "stopped"
         options:
           hidden: yes
   }


### PR DESCRIPTION
Instead of just a boolean indication 'playing' (true/false), the plugin now supports 3 states for more granularity; playing, paused, stopped.